### PR TITLE
Faster el.extend

### DIFF
--- a/src/el.js
+++ b/src/el.js
@@ -60,14 +60,31 @@ export function el (tagName) {
 }
 
 el.extend = function (tagName) {
-  return function () {
-    var args = new Array(arguments.length);
+  return function (a, b, c, d, e, f) {
+    var len = arguments.length;
 
-    for (var i = 0; i < args.length; i++) {
-      args[i] = arguments[i];
+    switch (len) {
+      case 0: return el(tagName);
+      case 1: return el(tagName, a);
+      case 2: return el(tagName, a, b);
+      case 3: return el(tagName, a, b, c);
+      case 4: return el(tagName, a, b, c, d);
+      case 5: return el(tagName, a, b, c, d, e);
+      case 6: return el(tagName, a, b, c, d, e, f);
     }
 
-    return el.apply(this, [tagName].concat(args));
+    var args = new Array(len + 1);
+    var arg, i = 0;
+
+    args[0] = tagName;
+
+    while (i < len) {
+        // args[1] = arguments[0] and so on
+        arg = arguments[i++];
+        args[i] = arg;
+    }
+
+    return el.apply(this, args);
   }
 }
 

--- a/test/test.js
+++ b/test/test.js
@@ -240,6 +240,21 @@ module.exports = function (frzr) {
     t.equals(destroyed2, true, 'destroyed Test2');
   });
 
+  test('create extended el with any number of arguments', function (t) {
+    t.plan(8);
+
+    var p = frzr.el.extend('p');
+
+    t.equals(p().childNodes.length, 0);
+    t.equals(p('a').childNodes.length, 1);
+    t.equals(p('a', 'b').childNodes.length, 2);
+    t.equals(p('a', 'b', 'c').childNodes.length, 3);
+    t.equals(p('a', 'b', 'c', 'd').childNodes.length, 4);
+    t.equals(p('a', 'b', 'c', 'd', 'e').childNodes.length, 5);
+    t.equals(p('a', 'b', 'c', 'd', 'e', 'f').childNodes.length, 6);
+    t.equals(p('a', 'b', 'c', 'd', 'e', 'f', 'g').childNodes.length, 7);
+  });
+
   test('coverage special cases', function (t) {
     t.plan(7);
 


### PR DESCRIPTION
This lowers the cost of `el.extend()` with a limited number of arguments to virtually none, making this:

```js
// We've created `var h1 = el.extend('h1');` before
h1('Hello World');
```

Just as fast as:

```js
el('h1', 'Hello World');
```